### PR TITLE
fixed devise problem

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
   </head>
   <body>
     <%= render "shared/flash" %>
-    <div class="content <%= "ms-5" unless current_page?(controller:"venues", action: "index") %>">
+    <div class="content <%= "ms-5" unless current_page?(venues_path) %>">
       <div class="bg-red">
       </div>
       <%= yield %>


### PR DESCRIPTION
when Devise (like Devise::Sessions#new for login) is handling a request, current_page? tries to interpret controller: "venues" within the Devise namespace, leading to No route matches {:action=>"index", :controller=>"devise/venues"}.

The solution is to use the named route helper venues_path instead. This is the standard and most reliable way to reference a specific URL in Rails, as it doesn't rely on the current controller context.