### PR TITLE
Fix back button js bugs

### DIFF
--- a/app/assets/stylesheets/components/_location.scss
+++ b/app/assets/stylesheets/components/_location.scss
@@ -79,6 +79,7 @@
 .form-control {
   padding-right: 99px; /* This padding should accommodate the button's width + right offset */
   box-sizing: border-box;
+  color: black;
 }
 
 /* --- TEXT COLORS (existing, keep as is) --- */

--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -24,3 +24,7 @@
   box-shadow: 0 2px 6px #00000026;
   border-radius: 9px;
 }
+
+#query {
+  color: black;
+}

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -61,3 +61,7 @@
   /* margin-top: auto; *//* If you want it pushed to the bottom of the section */
   color: #333; /* Dark gray for input labels/placeholders */
 }
+
+.search-fields-container .flatpickr-input {
+  color: black; // Force the text in the datepicker input to black
+}

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -1,11 +1,35 @@
 // app/javascript/controllers/datepicker_controller.js
 
 import { Controller } from "@hotwired/stimulus"
-import flatpickr from "flatpickr"; // You need to import this to use new flatpickr()
+import flatpickr from "flatpickr";
+// REMOVE THIS LINE: import "flatpickr/dist/flatpickr.min.css";
 
 export default class extends Controller {
+  flatpickrInstance = null;
+
   connect() {
-    console.log("flatpickr")
-    flatpickr(this.element)
+    console.log("flatpickr Stimulus controller connected!");
+
+    if (this.element._flatpickr) {
+      console.log("Destroying existing flatpickr instance.");
+      this.element._flatpickr.destroy();
+    }
+
+    this.flatpickrInstance = flatpickr(this.element, {
+      altInput: true,
+      altFormat: "F j, Y",
+      dateFormat: "Y-m-d",
+      // Add other Flatpickr options as needed
+    });
+
+    console.log("Flatpickr initialized:", this.flatpickrInstance);
+  }
+
+  disconnect() {
+    console.log("flatpickr Stimulus controller disconnected.");
+    if (this.flatpickrInstance) {
+      this.flatpickrInstance.destroy();
+      this.flatpickrInstance = null;
+    }
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -1,14 +1,28 @@
+// app/javascript/controllers/mapbox_controller.js
+
 import { Controller } from "@hotwired/stimulus"
 import mapboxgl from 'mapbox-gl'
-import { Offcanvas } from "bootstrap"
+import { Offcanvas } from "bootstrap" // Assuming this is used elsewhere in your app
 
 export default class extends Controller {
   static values = { apiKey: String, markers: Array }
 
+  // Declare map as a class property, initialized to null
+  map = null;
+
   connect() {
+    console.log("Mapbox Stimulus controller connected!"); // Added for debugging
+
+    // Defensive check: If a map instance already exists on this element, destroy it first.
+    if (this.map) { // Check the class property where we store the map instance
+      console.log("Destroying existing Mapbox map instance.");
+      this.map.remove(); // Mapbox GL JS uses .remove() to destroy the map
+      this.map = null; // Clear the reference
+    }
+
     mapboxgl.accessToken = this.apiKeyValue
     this.map = new mapboxgl.Map({
-      container: this.element,
+      container: this.element, // this.element is the div with data-controller="map"
       style: "mapbox://styles/mapbox/streets-v12",
     });
 
@@ -18,11 +32,22 @@ export default class extends Controller {
     valid.forEach(m => this._addMarker(m))
 
     if (valid.length > 0) {
-      this._fitMapToMarkers(valid)
+      this._fitMapToMarkers(valid) // Pass valid markers to the method
     } else {
       // no markers then we show Tokyo
       this.map.setCenter([139.6917, 35.6895])
       this.map.setZoom(10)
+    }
+
+    console.log("Mapbox map initialized:", this.map); // Added for debugging
+  }
+
+  // ADD THIS DISCONNECT METHOD
+  disconnect() {
+    console.log("Mapbox Stimulus controller disconnected."); // Added for debugging
+    if (this.map) {
+      this.map.remove(); // Crucial: destroy the map instance when the controller disconnects
+      this.map = null; // Clear the reference
     }
   }
 
@@ -40,9 +65,10 @@ export default class extends Controller {
     })
   }
 
-  _fitMapToMarkers() {
+  // Modified _fitMapToMarkers to accept markers as an argument
+  _fitMapToMarkers(markers) {
     const bounds = new mapboxgl.LngLatBounds()
-    this.markersValue.forEach(m => bounds.extend([m.lng, m.lat]))
+    markers.forEach(m => bounds.extend([m.lng, m.lat])) // Use the passed markers
     this.map.fitBounds(bounds, { padding: 70, maxZoom: 15, duration: 0 })
   }
 }

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -62,6 +62,14 @@ export default class extends Controller {
     this.tomSelect.addOption(this.masterOptions);
     this.tomSelect.refreshOptions(false);
 }
+ // ADD THIS DISCONNECT METHOD
+  disconnect() {
+    console.log("TomSelect Stimulus controller disconnected.");
+    if (this.tomSelect) {
+      this.tomSelect.destroy(); // Crucial: destroy the TomSelect instance
+      this.tomSelect = null; // Clear the reference
+    }
+  }
 
   clearInput(e) {
     console.log(e, "trigger")


### PR DESCRIPTION
- Added disconnect to flatpicker, tom select, and mapbox JS controllers. When going back a page turbo was creating multiple instances of these objects. Adding disconnect has corrected these bugs
-Made the datepicker font black instead of grey. 
-Made the venue search field entry black, but left the "search" placeholder grey.