### PR TITLE
fixed profile image squish on heroku

### DIFF
--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -127,8 +127,8 @@
 
 
 .profile-image-container { /* This class is specific to the index page */
-  width: 150px; /* Smaller size for index list */
-  height: 150px;
+  width: 100px; /* Smaller size for index list */
+  height: 100px;
   overflow: hidden;
   border-radius: 50%;
   border: 2px solid #C6C1B5;

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <div class="profile-header d-flex justify-content-between align-items-center p-4">
-  <div>
+  <div class="profile-image-container">
     <% if @user.photo.attached? %>
       <%= image_tag @user.photo,
             class: "profile-image",


### PR DESCRIPTION
added container class for profile pic so it wont squish on heroku. reduced size from 150 to 100px.